### PR TITLE
Bug-Fix/favorites and extensions initialization

### DIFF
--- a/Browser/Classes/WebView2Service/Class_WV2Service.Private.Extensions.cs
+++ b/Browser/Classes/WebView2Service/Class_WV2Service.Private.Extensions.cs
@@ -94,7 +94,7 @@ namespace WV2Service
                 throw new Exception($"Failed to load extensions:\n{ex.Message}");
             }
         }
-        private async Task<IReadOnlyList<CoreWebView2BrowserExtension>> GetBrowserExtensionsAsync(WebView2 webView, CoreWebView2Environment environment, CoreWebView2Profile profile)
+        private async Task<IReadOnlyList<CoreWebView2BrowserExtension>> GetBrowserExtensionsListAsync(WebView2 webView, CoreWebView2Environment environment, CoreWebView2Profile profile)
         {
             try
             {

--- a/Browser/Classes/WebView2Service/Class_WV2Service.Private.History.cs
+++ b/Browser/Classes/WebView2Service/Class_WV2Service.Private.History.cs
@@ -249,6 +249,12 @@ namespace WV2Service
             }
             catch (SqliteException ex)
             {
+                if (ex.Message.Contains("no such table")) // to ignore initial start-up error when url table has not been created yet
+                {
+                    Console.WriteLine($"Warning: {ex.Message}");
+                    return null; // Return an empty DataTable
+                }
+
                 throw new SqliteException(ex.Message, ex.SqliteErrorCode);
             }
         }
@@ -275,6 +281,8 @@ namespace WV2Service
                 Path.Combine(ProfileFolder, "EBWebView", "Default", "History");
 
             DataTable data = await GetFavorites(favoritesFilePath);
+
+            if (data == null ) { return null; }
 
             Dictionary<string, string> favoritesDict = new Dictionary<string, string>();
             foreach (DataRow row in data.Rows)

--- a/Browser/Classes/WebView2Service/Class_WV2Service.Public.Extensions.cs
+++ b/Browser/Classes/WebView2Service/Class_WV2Service.Public.Extensions.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.Web.WebView2.Core;
+using Microsoft.Web.WebView2.WinForms;
+using System.Diagnostics;
+
+namespace WV2Service
+{
+    public partial class WebViewService
+    {
+        public void EnsureExtensionsDirectory() // added to allow easy installation of extensions for now
+        {
+            string appBaseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+            _addExtensionsDirectory = Path.Combine(appBaseDirectory, "Extensions_Local");
+
+            if (!Directory.Exists(_addExtensionsDirectory))
+            {
+                Directory.CreateDirectory(_addExtensionsDirectory);
+            }
+        }
+        public async Task<List<string>> GetExtensionsList()
+        {
+            List<string> extensions = new List<string>();
+
+            IReadOnlyList<CoreWebView2BrowserExtension> extensionsList = await GetBrowserExtensionsListAsync(WebViewControl, environment, Profile);
+
+            foreach (var extension in extensionsList)
+            {
+                extensions.Add(extension.Name);
+                Console.WriteLine($"- {extension.Name}, ID: {extension.Id}");
+            }
+
+            return extensions;
+        }
+        public List<string> GetExtensionsPath()
+        {
+            string[] subDirectories = Directory.GetDirectories(_addExtensionsDirectory);
+
+            List<string> pathList = new List<string>();
+
+            foreach (string subDir in subDirectories)
+            {
+                pathList.Add(subDir);
+            }
+
+            return pathList;
+        }
+    }
+}

--- a/Browser/Classes/WebView2Service/Class_WV2Service.Public.Init.cs
+++ b/Browser/Classes/WebView2Service/Class_WV2Service.Public.Init.cs
@@ -62,19 +62,5 @@ namespace WV2Service
         {
             EnableNavigationMonitoring(WebViewControl, environment);
         }
-        public async Task<List<string>> GetExtensions()
-        {
-            List<string> extensions = new List<string>();
-
-            IReadOnlyList<CoreWebView2BrowserExtension> extensionsList =  await GetBrowserExtensionsAsync(WebViewControl, environment, Profile);
-
-            foreach (var extension in extensionsList)
-            {
-                extensions.Add(extension.Name);
-                Console.WriteLine($"- {extension.Name}, ID: {extension.Id}");
-            }
-
-            return extensions;
-        }
     }
 }

--- a/Browser/Classes/WebView2Service/Class_WV2Service.cs
+++ b/Browser/Classes/WebView2Service/Class_WV2Service.cs
@@ -9,6 +9,7 @@ namespace WV2Service
     {
         private WV2ServiceModel _WebViewModel;
         private string _TempFolder { get; set; }
+        private string _addExtensionsDirectory { get; set; }
         public ClearManager Clear { get; }
         public NavigationManager Navigation { get; }
         public event PropertyChangedEventHandler? PropertyChanged;


### PR DESCRIPTION
- added null check for favorites
- dynamically scan the extensions folder to be able to add new extensions
   -  it is still hard coded to only add ublock to private windows (ignored if ublock does not exist in the folder)
   - extensions are added only on start-up still